### PR TITLE
問題

### DIFF
--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -64,9 +64,10 @@ class UserController extends BaseController
         }
 
         $valid_email = $validation->getEmail();
-        $email_exists = User::checkEmailExists($valid_email);
+        $user = new User;
+        $email_exists = $user->checkEmailExists($valid_email);
         if($email_exists === false){
-            $_SESSION["error_msgs"][] = "メールアドレスはすでに使われています";
+            $_SESSION["error_msgs"][] = $user->getErrorMessages();
             return;
         }
 
@@ -81,7 +82,7 @@ class UserController extends BaseController
         $result = $change_email->insertEmail($_SESSION["user_id"]);
         if($result === false){
             session_start();
-            $_SESSION["error_msgs"][] = "エラーが発生しました。";
+            $_SESSION["error_msgs"][] = $this->getErrorMessages();
             return header(sprintf("Location: ../auth/edit_email.php?user_id=%s", $_SESSION["user_id"]));
         }
     }
@@ -162,8 +163,9 @@ class UserController extends BaseController
             return header("Location: ../user/delete.php");
         }
 
-        // 新規登録画面へ
-        return header("Location: ../auth/register.php");
+        session_destroy();
+        // ログイン画面へ
+        return header("Location: ../auth/login.php");
     }
 
 }

--- a/app/Model/ChangeEmail.php
+++ b/app/Model/ChangeEmail.php
@@ -15,6 +15,7 @@ class ChangeEmail extends User{
             $stmh = $pdo->query($query);
 
         }catch(PDOException $e){
+            $this->error_msgs = "仮登録に失敗しました。";
             error_log("仮登録に失敗しました");
             error_log($e->getMessage());
             error_log($e->getTraceAsString());

--- a/app/Services/UserDeleteService.php
+++ b/app/Services/UserDeleteService.php
@@ -4,7 +4,7 @@ class UserDeleteService {
     private static function sendEmailForUpdateEmail($email, $token){
         $url = sprintf('http://localhost:8000/view/user/delete_confirm.php?token=%s', $token);
 
-        mail($email, '登録確認メール', $url);
+        mail($email, '退会確認', $url);
     }
 
     // token発行メソッド内で、メール送信

--- a/app/Services/UserReRegisterService.php
+++ b/app/Services/UserReRegisterService.php
@@ -1,0 +1,17 @@
+<?php
+class UserReRegisterService {
+    // 本登録用のURLを記載したメールを送信
+    private static function sendEmailForReRegister($token){
+        $url = sprintf('http://localhost:8000/view/auth/main_reregister.php?token=%s', $token);
+
+        mail($_POST["email"], '再登録', $url);
+    }
+
+    // token発行メソッド内で、メール送信
+    public static function publishToken(){
+        $token = uniqid();
+        self::sendEmailForReRegister($token);
+
+        return $token;
+    }
+}

--- a/app/view/auth/main_reregister.php
+++ b/app/view/auth/main_reregister.php
@@ -1,0 +1,24 @@
+<?php
+require_once './../../controller/LoginController.php';
+
+if ($_SERVER["REQUEST_METHOD"] === 'POST') {
+    $controller = new LoginController;
+    $controller->mainReRegister();
+}
+
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>再登録</title>
+</head>
+<body>
+    <form action="" method="post">
+        <p>再登録しますか?</p>
+        <input class="btn btn-secondary" type="submit" value="再登録">
+    </form>
+</body>
+</html>

--- a/app/view/auth/register.php
+++ b/app/view/auth/register.php
@@ -2,12 +2,14 @@
 session_start();
 require_once './../../controller/LoginController.php';
 
+
 if ($_SERVER["REQUEST_METHOD"] === 'POST') {
     $controller = new LoginController;
     $controller->register();
 }
 
 $error_msgs = $_SESSION["error_msgs"];
+
 unset($_SESSION["error_msgs"]);
 ?>
 
@@ -34,8 +36,12 @@ unset($_SESSION["error_msgs"]);
         <div>
         <p>新規登録用のメールを送信します。送信ボタンを押して、メールをご確認ください。</p>
         <input class="btn btn-secondary" type="submit" value="送信">
+        <br>
         </div>
     </form>
+
+<br>
+<a href="reregister.php">再登録はこちら</a>
 
 <?php if ($error_msgs): ?>
     <?php foreach ($error_msgs as $error_msg): ?>

--- a/app/view/auth/reregister.php
+++ b/app/view/auth/reregister.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+require_once './../../controller/LoginController.php';
+
+if ($_SERVER["REQUEST_METHOD"] === 'POST') {
+    $controller = new LoginController;
+    $controller->reRegister();
+}
+
+$error_msgs = $_SESSION["error_msgs"];
+unset($_SESSION["error_msgs"]);
+?>
+
+<?php require_once("../layouts/header.php"); ?>
+
+<title>再登録</title>
+</head>
+<body class="text-center">
+<h1>再登録</h1>
+<div class="mx-auto" style="width:400px;">
+<p>再登録用のメールを送信します。</p>
+    <form class="form-group" action="" method="post">
+        <label>メールアドレス</label>
+        <input type="text" name="email" class="form-control" placeholder="メールアドレス">
+        <br>
+        <p>再登録用のメール送信</p>
+        <input class="btn btn-secondary" type="submit" value="送信">
+    </form>
+
+<?php if ($error_msgs): ?>
+    <?php foreach ($error_msgs as $error_msg): ?>
+        <p><?php echo $error_msg; ?></p>
+    <?php endforeach;?>
+<?php endif;?>
+</div>
+</body>
+</html>


### PR DESCRIPTION
　　ログイン：退会済みのユーザもログインできてしまう。
　　新規登録：論理削除により退会済みのユーザーのemailが残るので、checkEmailExists()に引っかかってしまう。
解決策
　　ログイン：User.phpにisSoftDleted()を用意し、退会のチェック。
 　新規作成: 再登録用のページ、メソッドを用意する。
       再登録画面を用意し、メールアドレスを入力、トークン生成
       メールアドレスに送信したURLにて、トークンと一致するレコードのdeleted_atをNULLに更新